### PR TITLE
[fix] Fix CORS error on autocomplete

### DIFF
--- a/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
+++ b/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
@@ -53,6 +53,7 @@
                 data: JSON.stringify(apiRequestData),
                 contentType: "application/json",
                 dataType: "json",
+                ignoreCSRFHeader: true,
                 success: function (response) {
                     var htmlResponse = apiAcRenderer.getHtml(JSON.stringify(response), searchTerm);
                     if(apiRequestData.test) { console.log(JSON.stringify(response)); console.log(htmlResponse);}


### PR DESCRIPTION
This sets the ignoreCSRFHeader option on the request, which prevents shopware from setting that header. This only affects older versions of Shopware, as the current one never sets the X-CSRF-Token header for cross-domain requests: https://github.com/shopware/shopware/blob/5.7/themes/Frontend/Responsive/frontend/_public/src/js/jquery.csrf-protection.js#L160