### PR TITLE
[fix] Don't do fallback on intentional abort

### DIFF
--- a/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
+++ b/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
@@ -40,7 +40,7 @@
             me.lastSearchTerm = $.trim(searchTerm);
 
             if (me.lastSearchAjax) {
-                me.lastSearchAjax.abort();
+                me.lastSearchAjax.abort('searchTermChanged');
             }
 
             var requestUrl = window.rtuxApiHelper.getApiRequestUrl();
@@ -61,7 +61,10 @@
                     me.showResult(htmlResponse);
                     $.publish('plugin/swSearch/onRtuxApiSearchResponse', [ this, searchTerm, response ]);
                 },
-                error: function (response) {
+                error: function (response, statusText) {
+                    if (statusText === 'searchTermChanged') {
+                        return;
+                    }
                     //fallback to Shopware5 default ajaxSearch event
                     console.log(response.status + ": " + response.statusText + ": " + response.responseText);
                     me.superclass.triggerSearchRequest.call(me, searchTerm);


### PR DESCRIPTION
If the user changes the input, the pending autocomplete request is aborted, which triggers the error handler and initiates a fallback request. Prevent this by setting the statusText when aborting and then checking for it in the error function.