### PR TITLE
[fix] add missing use statement

### DIFF
--- a/Frontend/Boxalino/Helper/BxData.php
+++ b/Frontend/Boxalino/Helper/BxData.php
@@ -1,5 +1,6 @@
 <?php
 
+use Shopware\Components\Api\Resource\Translation;
 use Shopware\Components\ReflectionHelper;
 
 /**


### PR DESCRIPTION
On PR #1 I made a mistake and forgot to add the use statement for a class I used.