### PR TITLE
[fix] remove nested ternary without parentheses

### DIFF
--- a/Frontend/Boxalino/lib/BxFacets.php
+++ b/Frontend/Boxalino/lib/BxFacets.php
@@ -1051,8 +1051,8 @@ class BxFacets
 
             $facetRequest = new \com\boxalino\p13n\api\thrift\FacetRequest();
             $facetRequest->fieldName = $fieldName;
-            $facetRequest->numerical = $type == 'ranged' ? true : $type == 'numerical' ? true : false;
-            $facetRequest->range = $type == 'ranged' ? true : false;
+            $facetRequest->numerical = $type == 'ranged' || $type == 'numerical';
+            $facetRequest->range = $type == 'ranged';
             $facetRequest->boundsOnly = $facet['boundsOnly'];
             $facetRequest->selectedValues = $this->facetSelectedValue($fieldName, $type);
             $facetRequest->andSelectedValues = $andSelectedValues;


### PR DESCRIPTION
Nested ternaries without parentheses were [deprecated in PHP 7.4 and are an error in PHP 8](https://wiki.php.net/rfc/ternary_associativity). In this particular case it can be replaced by a simple OR condition. I also searched for other nested ternaries in the repo and they all use parentheses.
