### PR TITLE
Fix pathInfo overwritten with referer header

### DIFF
--- a/Frontend/Boxalino/Bundle/Search/BoxalinoSearch.php
+++ b/Frontend/Boxalino/Bundle/Search/BoxalinoSearch.php
@@ -76,12 +76,6 @@ abstract class Shopware_Plugins_Frontend_Boxalino_Bundle_Search_BoxalinoSearch
         }
 
         $address = $_SERVER['HTTP_REFERER'];
-        $basePath = $request->getBasePath();
-        $start = strpos($address, $basePath) + strlen($basePath);
-        $end = strpos($address, '?');
-        $length = $end ? $end - $start : strlen($address);
-        $pathInfo = substr($address, $start, $length);
-        $request->setPathInfo($pathInfo);
         $params = explode('&', substr ($address,strpos($address, '?')+1, strlen($address)));
         foreach ($params as $index => $param){
             $keyValue = explode("=", $param);

--- a/Frontend/Boxalino/Controllers/Frontend/RecommendationSlider.php
+++ b/Frontend/Boxalino/Controllers/Frontend/RecommendationSlider.php
@@ -189,6 +189,7 @@ class Shopware_Controllers_Frontend_RecommendationSlider extends Enlight_Control
             $this->View()->loadTemplate('frontend/_includes/product_slider_items.tpl');
             $path = Shopware()->Plugins()->Frontend()->Boxalino()->Path();
             $this->View()->addTemplateDir($path . 'Views/emotion/');
+            $this->View()->extendsTemplate('frontend/plugins/boxalino/_includes/product_slider_item.tpl');
             $this->View()->extendsTemplate('frontend/plugins/boxalino/listing/product-box/box-emotion.tpl');
             $this->View()->assign('articles', $articles);
             $this->View()->assign($this->getTrackingHtmlAttributes($helper, $choiceId));

--- a/Frontend/Boxalino/Views/emotion/frontend/plugins/boxalino/_includes/product_slider_item.tpl
+++ b/Frontend/Boxalino/Views/emotion/frontend/plugins/boxalino/_includes/product_slider_item.tpl
@@ -6,6 +6,6 @@
            {include file="frontend/plugins/boxalino/blog/recommendation.tpl" sArticle=$article}
        </div>
    {else}
-       {$smarty.block.parent}
+       {include file="frontend/listing/box_article.tpl" sArticle=$article productBoxLayout=$productBoxLayout fixedImageSize=$fixedImageSize}
    {/if}
 {/block}


### PR DESCRIPTION
If pathInfo is set to the Referer it can lead to strange side effects. In our case the baseUrl variable in the templates was something like '/dehttp://...'. 

If overwriting the pathInfo here is actually needed it would also be possible to clone the request object instead.