### PR TITLE
[fix] publish swSearch events on frontend

### DIFF
--- a/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
+++ b/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
@@ -39,6 +39,8 @@
             me.$loader.fadeIn(me.opts.animationSpeed);
             me.lastSearchTerm = $.trim(searchTerm);
 
+            $.publish('plugin/swSearch/onSearchRequest', [me, searchTerm]);
+
             if (me.lastSearchAjax) {
                 me.lastSearchAjax.abort('searchTermChanged');
             }
@@ -60,6 +62,7 @@
 
                     me.showResult(htmlResponse);
                     $.publish('plugin/swSearch/onRtuxApiSearchResponse', [ this, searchTerm, response ]);
+                    $.publish('plugin/swSearch/onSearchResponse', [me, searchTerm, htmlResponse]);
                 },
                 error: function (response, statusText) {
                     if (statusText === 'searchTermChanged') {


### PR DESCRIPTION
Adds the same events as the original triggerSearchRequest, so other frontend code can hook into the search. see https://github.com/shopware/shopware/blob/5.5/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js#L378