### PR TITLE
[autocomplete] Use configured widget

### DIFF
--- a/Frontend/Boxalino/FrontendInterceptor.php
+++ b/Frontend/Boxalino/FrontendInterceptor.php
@@ -361,6 +361,7 @@ class Shopware_Plugins_Frontend_Boxalino_FrontendInterceptor
             "suggestionsCount" => $this->Config()->get('boxalino_textual_suggestion_limit'),
             "apiKeyJs" => $this->Config()->get('boxalino_api_key_js'),
             "apiAccountJs" => $this->Config()->get('boxalino_account'),
+            "widget" => $this->Config()->get('boxalino_autocomplete_widget_name')
         ];
     }
 

--- a/Frontend/Boxalino/Views/emotion/frontend/plugins/boxalino/index_5_3.tpl
+++ b/Frontend/Boxalino/Views/emotion/frontend/plugins/boxalino/index_5_3.tpl
@@ -17,6 +17,7 @@
                 "apiPreferentialKey": "{$bxApiConfig['apiKeyJs']}",
                 "dev": '{$bxApiConfig["dev"]}'=='1' ? true : false,
                 "test": '{$bxApiConfig["test"]}'=='1' ? true : false,
+                "widget": '{$bxApiConfig["widget"]}',
                 "suggestionsCount":{$bxApiConfig['suggestionsCount']},
                 "productsCount":{$bxApiConfig['productsCount']},
                 "language": "{$Shop->getLocale()->toString()}",

--- a/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
+++ b/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
@@ -13,7 +13,7 @@
         return window.rtuxApiHelper.getApiRequestData(
             window.rtuxAutocomplete['apiPreferentialAccount'],
             window.rtuxAutocomplete['apiPreferentialKey'],
-            'autocomplete',
+            window.rtuxAutocomplete['widget'],
             window.rtuxAutocomplete['language'],
             'products_group_id',
             window.rtuxAutocomplete['productsCount'],


### PR DESCRIPTION
Uses the widget which is configured in the plugin options instead of always using "autocomplete". 