### PR TITLE
[fix] make compatible with case sensitive service names

### DIFF
--- a/Frontend/Boxalino/Bundle/Narrative/View.php
+++ b/Frontend/Boxalino/Bundle/Narrative/View.php
@@ -27,7 +27,7 @@ class Shopware_Plugins_Frontend_Boxalino_Bundle_Narrative_View
 
     public function createView($viewElement, $additionalParameter, $otherTemplateData = array())
     {
-        $view =  new Enlight_View_Default(Shopware()->Container()->get('Template'));
+        $view =  new Enlight_View_Default(Shopware()->Container()->get('template'));
 
         $this->applyThemeConfig($view);
         $this->assignSubRenderings($view, $viewElement);
@@ -41,7 +41,7 @@ class Shopware_Plugins_Frontend_Boxalino_Bundle_Narrative_View
         $inheritance = Shopware()->Container()->get('theme_inheritance');
 
         /** @var \Shopware\Models\Shop\Shop $shop */
-        $shop = Shopware()->Container()->get('Shop');
+        $shop = Shopware()->Container()->get('shop');
         $config = $inheritance->buildConfig($shop->getTemplate(), $shop, false);
         Shopware()->Container()->get('template')->addPluginsDir(
             $inheritance->getSmartyDirectories(

--- a/Frontend/Boxalino/Helper/BxRender.php
+++ b/Frontend/Boxalino/Helper/BxRender.php
@@ -104,7 +104,7 @@ class Shopware_Plugins_Frontend_Boxalino_Helper_BxRender
     }
 
     protected function createView($viewElement, $additionalParameter, $otherTemplateData = array()) {
-        $view =  new Enlight_View_Default(Shopware()->Container()->get('Template'));
+        $view =  new Enlight_View_Default(Shopware()->Container()->get('template'));
         $this->applyThemeConfig($view);
         $this->assignSubRenderings($view, $viewElement);
         $this->assignTemplateData($view, $viewElement, $additionalParameter, $otherTemplateData);
@@ -249,7 +249,7 @@ class Shopware_Plugins_Frontend_Boxalino_Helper_BxRender
         $inheritance = Shopware()->Container()->get('theme_inheritance');
 
         /** @var \Shopware\Models\Shop\Shop $shop */
-        $shop = Shopware()->Container()->get('Shop');
+        $shop = Shopware()->Container()->get('shop');
         $config = $inheritance->buildConfig($shop->getTemplate(), $shop, false);
         Shopware()->Container()->get('template')->addPluginsDir(
             $inheritance->getSmartyDirectories(

--- a/Frontend/Boxalino/SearchInterceptor.php
+++ b/Frontend/Boxalino/SearchInterceptor.php
@@ -105,7 +105,7 @@ class Shopware_Plugins_Frontend_Boxalino_SearchInterceptor
         if (!$this->Config()->get('boxalino_active')) {
             return null;
         }
-        $view = new Enlight_View_Default($this->get('Template'));
+        $view = new Enlight_View_Default($this->get('template'));
         $view = $this->prepareViewConfig($view);
 
         $searchBundle = new Shopware_Plugins_Frontend_Boxalino_Bundle_Search($this->Helper(), "landingPage");
@@ -969,7 +969,7 @@ class Shopware_Plugins_Frontend_Boxalino_SearchInterceptor
         $inheritance = $this->container->get('theme_inheritance');
 
         /** @var \Shopware\Models\Shop\Shop $shop */
-        $shop = $this->container->get('Shop');
+        $shop = $this->container->get('shop');
 
         $config = $inheritance->buildConfig($shop->getTemplate(), $shop, false);
 
@@ -1022,7 +1022,7 @@ class Shopware_Plugins_Frontend_Boxalino_SearchInterceptor
         $inheritance = $this->container->get('theme_inheritance');
 
         /** @var \Shopware\Models\Shop\Shop $shop */
-        $shop = $this->container->get('Shop');
+        $shop = $this->container->get('shop');
 
         $config = $inheritance->buildConfig($shop->getTemplate(), $shop, false);
 


### PR DESCRIPTION
Shopware 5.7 has case sensitive service names, meaning that 'Shop' must always be 'shop'