### PR TITLE
[autocomplete] use trimmed search term

### DIFF
--- a/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
+++ b/Frontend/Boxalino/Views/responsive/frontend/_resources/javascript/boxalinoApiAc.js
@@ -46,7 +46,7 @@
             }
 
             var requestUrl = window.rtuxApiHelper.getApiRequestUrl();
-            var apiRequestData = _getApiRequestData(searchTerm);
+            var apiRequestData = _getApiRequestData(me.lastSearchTerm);
             var apiAcRenderer = $.getRtuxApiAcRenderer();
 
             me.lastSearchAjax = $.ajax({
@@ -57,7 +57,7 @@
                 dataType: "json",
                 ignoreCSRFHeader: true,
                 success: function (response) {
-                    var htmlResponse = apiAcRenderer.getHtml(JSON.stringify(response), searchTerm);
+                    var htmlResponse = apiAcRenderer.getHtml(JSON.stringify(response), me.lastSearchTerm);
                     if(apiRequestData.test) { console.log(JSON.stringify(response)); console.log(htmlResponse);}
 
                     me.showResult(htmlResponse);


### PR DESCRIPTION
Uses the trimmed search term for the request. The untrimmed search term is still used for the published events, which is like the [original Shopware code](https://github.com/shopware/shopware/blob/v5.7.3/themes/Frontend/Responsive/frontend/_public/src/js/jquery.search.js#L383).